### PR TITLE
fix(renovate): ignore typos pre-commit hook updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,15 @@
       "commitMessagePrefix": "chore(hooks):"
     },
     {
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "matchDepNames": [
+        "crate-ci/typos"
+      ],
+      "enabled": false
+    },
+    {
       "matchFileNames": [
         "**/pyproject.toml"
       ],


### PR DESCRIPTION
## Summary
- prevent Renovate from re-opening crate-ci/typos pre-commit hook bumps
- document the practical repo policy in config rather than fighting each PR by hand

## Why
Renovate tracks the pre-commit repository tag for crate-ci/typos, but CI installs the Python package and v1.47.1 is not yet on PyPI. That causes generated-project lint to fail and Renovate to re-open the same bump repeatedly after a manual revert.

## Verification
- validated renovate.json syntax with python -m json.tool
- local pre-commit checks passed during commit
- closed PR #729 because it was the same broken unpublished bump
